### PR TITLE
changed inline int signal_backtrace__ to static inline to fix complia…

### DIFF
--- a/modules/faultd/module/src/faultd_handler.c
+++ b/modules/faultd/module/src/faultd_handler.c
@@ -50,7 +50,7 @@ static faultd_client_t* faultd_client__ = NULL;
 static faultd_info_t faultd_info__;
 static int localfd__ = -1; 
 
-inline int signal_backtrace__(void** buffer, int size, ucontext_t* context,
+static inline int signal_backtrace__(void** buffer, int size, ucontext_t* context,
                               int distance)
 {
 #define IP_STACK_FRAME_NUMBER 3


### PR DESCRIPTION
…tion issue with newer gcc

I don't see any other programs referencing the int and changing it to static fixed the compilation issue, not sure if this is the right way to fix it?
